### PR TITLE
ci(release): trigger tag creation only on PR merge

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,12 +1,14 @@
 name: Create Tag on Merge
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - master
 
 jobs:
   create-tag:
+    if: github.event.pull_request.merged == true
     name: Create Tag
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Corrects the release workflow to only trigger on PR merge to master.