### PR TITLE
fix(runner): ensure lua state is always initialized

### DIFF
--- a/examples/salt_accept_and_ping.lua
+++ b/examples/salt_accept_and_ping.lua
@@ -1,0 +1,72 @@
+-- examples/salt_accept_and_ping.lua
+--
+-- Este workflow demonstra como esperar por uma nova chave de minion,
+-- aceitá-la automaticamente e, em seguida, usar o ID do novo minion
+-- em uma tarefa subsequente para verificá-lo com test.ping.
+
+TaskDefinitions = {
+  ["accept_and_ping_workflow"] = {
+    description = "Um workflow para aceitar uma nova chave de minion e depois pingá-la.",
+    tasks = {
+      {
+        name = "wait_and_accept_key",
+        description = "Espera até que uma nova chave pendente apareça e a aceita.",
+        command = function()
+          local log = require("log")
+          local salt = require("salt")
+
+          log.info("Aguardando uma nova chave de minion... O script ficará bloqueado aqui até que uma nova chave seja detectada.")
+          
+          local new_minion_id, err = salt.key.wait_and_accept()
+          
+          if err then
+            log.error("Falha ao esperar ou aceitar a chave: " .. err)
+            return false, "Falha ao aceitar a chave."
+          end
+          
+          log.info("Chave para o minion '" .. new_minion_id .. "' foi aceita com sucesso.")
+          
+          -- Retorna o ID do minion para que a próxima tarefa possa usá-lo
+          return true, "Chave aceita.", { minion_id = new_minion_id }
+        end
+      },
+      {
+        name = "ping_new_minion",
+        description = "Executa test.ping no minion que foi recém-aceito.",
+        depends_on = "wait_and_accept_key",
+        retries = 10,
+        command = function(params, inputs)
+          local log = require("log")
+          local salt = require("salt")
+          local data = require("data")
+
+          -- Obtém o minion_id da saída da tarefa anterior
+          local minion_id = inputs.wait_and_accept_key.minion_id
+          
+          if not minion_id then
+            log.error("O ID do minion não foi recebido da tarefa anterior.")
+            return false, "ID do minion não encontrado."
+          end
+          
+          log.info("Pingando o novo minion: '" .. minion_id .. "'...")
+          
+          local salt_client = salt.client()
+          local success, stdout, stderr, err = salt_client:target(minion_id):cmd("test.ping")
+          
+          if err or not success then
+            local error_message = "Falha ao pingar o minion '" .. minion_id .. "'."
+            if err then error_message = error_message .. " Erro: " .. err end
+            if stderr then error_message = error_message .. " Stderr: " .. stderr end
+            log.error(error_message)
+            return false, "Ping falhou."
+          end
+          
+          log.info("Resultado do Ping para '" .. minion_id .. "': " .. stdout)
+          log.info("Minion '" .. minion_id .. "' está online e respondendo.")
+          
+          return true, "Ping bem-sucedido."
+        end
+      }
+    }
+  }
+}

--- a/internal/luainterface/luainterface.go
+++ b/internal/luainterface/luainterface.go
@@ -535,6 +535,19 @@ func LogLoader(L *lua.LState) int {
 }
 func OpenLog(L *lua.LState) { L.PreloadModule("log", LogLoader) }
 
+// OpenAll preloads all available sloth-runner modules into the Lua state.
+func OpenAll(L *lua.LState) {
+	OpenExec(L)
+	OpenFs(L)
+	OpenNet(L)
+	OpenData(L)
+	OpenLog(L)
+	OpenSalt(L)
+	OpenPulumi(L)
+	OpenGit(L)
+	OpenPython(L)
+}
+
 // --- Parallel Module ---
 func newParallelFunction(tr types.TaskRunner) lua.LGFunction {
 	return func(L *lua.LState) int {

--- a/internal/luainterface/salt_helpers.go
+++ b/internal/luainterface/salt_helpers.go
@@ -1,0 +1,54 @@
+package luainterface
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// SaltKeyAction performs a salt-key action.
+func SaltKeyAction(args ...string) (string, error) {
+	stdout, stderr, err := RunCommand("salt-key", args...)
+	if err != nil {
+		return "", fmt.Errorf("command failed: %w, stderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		// salt-key often prints non-error info to stderr, but we return it anyway
+		return stdout, fmt.Errorf(stderr)
+	}
+	return stdout, nil
+}
+
+// SaltRunAction performs a salt-run action.
+func SaltRunAction(args ...string) (string, error) {
+	stdout, stderr, err := RunCommand("salt-run", args...)
+	if err != nil {
+		return "", fmt.Errorf("command failed: %w, stderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		return stdout, fmt.Errorf(stderr)
+	}
+	return stdout, nil
+}
+
+// SaltPing pings a minion.
+func SaltPing(minionID string) (bool, error) {
+	output, stderr, err := RunCommand("salt", minionID, "test.ping", "--out=json")
+	if err != nil {
+		return false, fmt.Errorf("command failed: %w, stderr: %s", err, stderr)
+	}
+	if stderr != "" {
+		return false, fmt.Errorf(stderr)
+	}
+
+	var result map[string]bool
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		return false, fmt.Errorf("failed to unmarshal ping result: %w", err)
+	}
+
+	pingSuccess, ok := result[minionID]
+	if !ok {
+		return false, fmt.Errorf("minion ID '%s' not found in ping response", minionID)
+	}
+
+	return pingSuccess, nil
+}

--- a/internal/taskrunner/taskrunner.go
+++ b/internal/taskrunner/taskrunner.go
@@ -198,6 +198,10 @@ func (tr *TaskRunner) runTask(ctx context.Context, t *types.Task, inputFromDepen
 	}
 
 	if t.CommandFunc != nil {
+		// Prepara o ambiente Lua para garantir que os módulos globais (log, exec, etc.) estejam disponíveis.
+		// Esta é a correção para o bug 'log is nil'.
+		luainterface.OpenAll(tr.L)
+
 		// Pass session to Lua context
 		var sessionUD *lua.LUserData
 		if session != nil {


### PR DESCRIPTION
This PR fixes a critical bug where the Lua execution environment (including the 'log' object) was not being correctly initialized for tasks. This ensures all modules are preloaded before any task command function is executed, resolving the 'attempt to index a non-table object(nil)' error.