### PR TITLE
feat: Add GCP module and export function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A flexible and extensible task runner application written in Go, powered by Lua 
     *   **`data` module:** Parse and serialize data in JSON and YAML format.
     *   **`log` module:** Log messages with different severity levels (info, warn, error, debug).
     *   **`salt` module:** Execute SaltStack commands (`salt`, `salt-call`) directly.
+    *   **`gcp` module:** Execute Google Cloud (`gcloud`) CLI commands.
 *   **📝 `values.yaml` Integration:** Pass configuration values to your Lua tasks through a `values.yaml` file, similar to Helm.
 *   **💻 Command-Line Interface (CLI):**
     *   `run`: Execute tasks from a Lua configuration file.

--- a/README.zh.md
+++ b/README.zh.md
@@ -21,6 +21,7 @@
     *   **`data` 模块:** 解析和序列化 JSON 和 YAML 数据。
     *   **`log` 模块:** 以不同的严重级别（info、warn、error、debug）记录消息。
     *   **`salt` 模块:** 直接执行 SaltStack 命令（`salt`、`salt-call`）。
+    *   **`gcp` 模块:** 执行谷歌云 (`gcloud`) 命令行指令。
 *   **📝 `values.yaml` 集成:** 通过 `values.yaml` 文件将配置值传递给您的 Lua 任务，类似于 Helm。
 *   **💻 命令行界面 (CLI):**
     *   `run`: 从 Lua 配置文件执行任务。

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -64,6 +64,45 @@ TaskDefinitions = {
 *   **Parâmetros (`params`):** Podem ser passados para as tarefas via linha de comando ou definidos na própria tarefa. A função `command` e as funções `run_if`/`abort_if` podem acessá-los.
 *   **Outputs (`deps`):** As funções Lua de `command` podem retornar uma tabela de outputs. Tarefas que dependem desta tarefa podem acessar esses outputs através do argumento `deps`.
 
+## Exportando Dados para a CLI
+
+Além dos outputs de tarefas, o `sloth-runner` fornece uma função global `export()` que permite passar dados de dentro de um script diretamente para a saída da linha de comando.
+
+### `export(tabela)`
+
+*   **`tabela`**: Uma tabela Lua cujos pares de chave-valor serão exportados.
+
+Quando você executa uma tarefa com a flag `--return`, os dados passados para a função `export()` serão mesclados com o output da tarefa final e impressos como um único objeto JSON. Se houver chaves duplicadas, o valor da função `export()` terá precedência.
+
+Isso é útil para extrair informações importantes de qualquer ponto do seu script, não apenas do valor de retorno da última tarefa.
+
+**Exemplo:**
+
+```lua
+command = function(params, deps)
+  -- Lógica da tarefa...
+  local some_data = {
+    info = "Este é um dado importante",
+    timestamp = os.time()
+  }
+  
+  -- Exporta a tabela
+  export(some_data)
+  
+  -- A tarefa pode continuar e retornar seu próprio output
+  return true, "Tarefa concluída", { status = "ok" }
+end
+```
+
+Executando com `--return` resultaria em uma saída JSON como:
+```json
+{
+  "info": "Este é um dado importante",
+  "timestamp": 1678886400,
+  "status": "ok"
+}
+```
+
 ## Módulos Built-in
 
 O Sloth-Runner expõe várias funcionalidades Go como módulos Lua, permitindo que suas tarefas interajam com o sistema e serviços externos. Além dos módulos básicos (`exec`, `fs`, `net`, `data`, `log`, `import`, `parallel`), o Sloth-Runner agora inclui módulos avançados para Git, Pulumi e Salt.

--- a/docs/en/core-concepts.md
+++ b/docs/en/core-concepts.md
@@ -64,6 +64,45 @@ TaskDefinitions = {
 *   **Parameters (`params`):** Can be passed to tasks via the command line or defined within the task itself. The `command` function and `run_if`/`abort_if` functions can access them.
 *   **Outputs (`deps`):** Lua `command` functions can return an outputs table. Tasks that depend on this task can access these outputs through the `deps` argument.
 
+## Exporting Data to the CLI
+
+In addition to task outputs, `sloth-runner` provides a global `export()` function that allows you to pass data from within a script directly to the command-line output.
+
+### `export(table)`
+
+*   **`table`**: A Lua table whose key-value pairs will be exported.
+
+When you run a task with the `--return` flag, the data passed to the `export()` function will be merged with the final task's output and printed as a single JSON object. If there are duplicate keys, the value from the `export()` function will take precedence.
+
+This is useful for extracting important information from any point in your script, not just from the return value of the last task.
+
+**Example:**
+
+```lua
+command = function(params, deps)
+  -- Task logic...
+  local some_data = {
+    info = "This is important data",
+    timestamp = os.time()
+  }
+  
+  -- Export the table
+  export(some_data)
+  
+  -- The task can continue and return its own output
+  return true, "Task completed", { status = "ok" }
+end
+```
+
+Running with `--return` would result in a JSON output like:
+```json
+{
+  "info": "This is important data",
+  "timestamp": 1678886400,
+  "status": "ok"
+}
+```
+
 ## Built-in Modules
 
 Sloth-Runner exposes various Go functionalities as Lua modules, allowing your tasks to interact with the system and external services. In addition to the basic modules (`exec`, `fs`, `net`, `data`, `log`, `import`, `parallel`), Sloth-Runner now includes advanced modules for Git, Pulumi, and Salt.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,6 +12,7 @@ Here you will find detailed guides, API references, and practical examples to he
     *   [Git Module](./modules/git.md)
     *   [Pulumi Module](./modules/pulumi.md)
     *   [Salt Module](./modules/salt.md)
+    *   [GCP Module](./modules/gcp.md)
 *   [Advanced Examples](./advanced-examples.md)
 
 ---

--- a/docs/en/modules/gcp.md
+++ b/docs/en/modules/gcp.md
@@ -1,0 +1,69 @@
+# GCP Module
+
+The `gcp` module provides a simple interface for executing Google Cloud CLI (`gcloud`) commands from within a `sloth-runner` task.
+
+## `gcp.exec(args)`
+
+Executes a `gcloud` command with the specified arguments.
+
+### Parameters
+
+*   `args` (table): A Lua table (array) of strings representing the arguments to pass to the `gcloud` command. For example, `{"compute", "instances", "list"}`.
+
+### Returns
+
+A table containing the result of the command execution with the following keys:
+
+*   `stdout` (string): The standard output from the command.
+*   `stderr` (string): The standard error output from the command.
+*   `exit_code` (number): The exit code of the command. An exit code of `0` typically indicates success.
+
+### Example
+
+This example defines a task that lists all Compute Engine instances in the `us-central1` region for a specific project.
+
+```lua
+-- examples/gcp_cli_example.lua
+
+TaskDefinitions = {
+  main = {
+    description = "A task to list GCP compute instances.",
+    tasks = {
+      {
+        name = "list-instances",
+        description = "Lists GCE instances in us-central1.",
+        command = function()
+          log.info("Listing GCP instances...")
+          
+          -- require the gcp module to make it available
+          local gcp = require("gcp")
+
+          -- Execute the gcloud command
+          local result = gcp.exec({
+            "compute", 
+            "instances", 
+            "list", 
+            "--project", "my-gcp-project-id",
+            "--zones", "us-central1-a,us-central1-b"
+          })
+
+          -- Check the result
+          if result and result.exit_code == 0 then
+            log.info("Successfully listed instances.")
+            print("--- INSTANCE LIST ---")
+            print(result.stdout)
+            print("---------------------")
+            return true, "GCP command successful."
+          else
+            log.error("Failed to list GCP instances.")
+            if result then
+              log.error("Stderr: " .. result.stderr)
+            end
+            return false, "GCP command failed."
+          end
+        end
+      }
+    }
+  }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,5 @@ Aqui você encontrará guias detalhados, referências de API e exemplos prático
     *   [Módulo Git](./modules/git.md)
     *   [Módulo Pulumi](./modules/pulumi.md)
     *   [Módulo Salt](./modules/salt.md)
+    *   [Módulo GCP](./modules/gcp.md)
 *   [Exemplos Avançados](./advanced-examples.md)

--- a/docs/modules/gcp.md
+++ b/docs/modules/gcp.md
@@ -1,0 +1,69 @@
+# GCP Module
+
+The `gcp` module provides a simple interface for executing Google Cloud CLI (`gcloud`) commands from within a `sloth-runner` task.
+
+## `gcp.exec(args)`
+
+Executes a `gcloud` command with the specified arguments.
+
+### Parameters
+
+*   `args` (table): A Lua table (array) of strings representing the arguments to pass to the `gcloud` command. For example, `{"compute", "instances", "list"}`.
+
+### Returns
+
+A table containing the result of the command execution with the following keys:
+
+*   `stdout` (string): The standard output from the command.
+*   `stderr` (string): The standard error output from the command.
+*   `exit_code` (number): The exit code of the command. An exit code of `0` typically indicates success.
+
+### Example
+
+This example defines a task that lists all Compute Engine instances in the `us-central1` region for a specific project.
+
+```lua
+-- examples/gcp_cli_example.lua
+
+TaskDefinitions = {
+  main = {
+    description = "A task to list GCP compute instances.",
+    tasks = {
+      {
+        name = "list-instances",
+        description = "Lists GCE instances in us-central1.",
+        command = function()
+          log.info("Listing GCP instances...")
+          
+          -- require the gcp module to make it available
+          local gcp = require("gcp")
+
+          -- Execute the gcloud command
+          local result = gcp.exec({
+            "compute", 
+            "instances", 
+            "list", 
+            "--project", "my-gcp-project-id",
+            "--zones", "us-central1-a,us-central1-b"
+          })
+
+          -- Check the result
+          if result and result.exit_code == 0 then
+            log.info("Successfully listed instances.")
+            print("--- INSTANCE LIST ---")
+            print(result.stdout)
+            print("---------------------")
+            return true, "GCP command successful."
+          else
+            log.error("Failed to list GCP instances.")
+            if result then
+              log.error("Stderr: " .. result.stderr)
+            end
+            return false, "GCP command failed."
+          end
+        end
+      }
+    }
+  }
+}
+```

--- a/docs/pt/core-concepts.md
+++ b/docs/pt/core-concepts.md
@@ -64,6 +64,45 @@ TaskDefinitions = {
 *   **Parâmetros (`params`):** Podem ser passados para as tarefas via linha de comando ou definidos na própria tarefa. A função `command` e as funções `run_if`/`abort_if` podem acessá-los.
 *   **Outputs (`deps`):** As funções Lua de `command` podem retornar uma tabela de outputs. Tarefas que dependem desta tarefa podem acessar esses outputs através do argumento `deps`.
 
+## Exportando Dados para a CLI
+
+Além dos outputs de tarefas, o `sloth-runner` fornece uma função global `export()` que permite passar dados de dentro de um script diretamente para a saída da linha de comando.
+
+### `export(tabela)`
+
+*   **`tabela`**: Uma tabela Lua cujos pares de chave-valor serão exportados.
+
+Quando você executa uma tarefa com a flag `--return`, os dados passados para a função `export()` serão mesclados com o output da tarefa final e impressos como um único objeto JSON. Se houver chaves duplicadas, o valor da função `export()` terá precedência.
+
+Isso é útil para extrair informações importantes de qualquer ponto do seu script, não apenas do valor de retorno da última tarefa.
+
+**Exemplo:**
+
+```lua
+command = function(params, deps)
+  -- Lógica da tarefa...
+  local some_data = {
+    info = "Este é um dado importante",
+    timestamp = os.time()
+  }
+  
+  -- Exporta a tabela
+  export(some_data)
+  
+  -- A tarefa pode continuar e retornar seu próprio output
+  return true, "Tarefa concluída", { status = "ok" }
+end
+```
+
+Executando com `--return` resultaria em uma saída JSON como:
+```json
+{
+  "info": "Este é um dado importante",
+  "timestamp": 1678886400,
+  "status": "ok"
+}
+```
+
 ## Módulos Built-in
 
 O Sloth-Runner expõe várias funcionalidades Go como módulos Lua, permitindo que suas tarefas interajam com o sistema e serviços externos. Além dos módulos básicos (`exec`, `fs`, `net`, `data`, `log`, `import`, `parallel`), o Sloth-Runner agora inclui módulos avançados para Git, Pulumi e Salt.

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -12,6 +12,7 @@ Aqui você encontrará guias detalhados, referências de API e exemplos prático
     *   [Módulo Git](./modules/git.md)
     *   [Módulo Pulumi](./modules/pulumi.md)
     *   [Módulo Salt](./modules/salt.md)
+    *   [Módulo GCP](./modules/gcp.md)
 *   [Exemplos Avançados](./advanced-examples.md)
 
 ---

--- a/docs/pt/modules/gcp.md
+++ b/docs/pt/modules/gcp.md
@@ -1,0 +1,69 @@
+# Módulo GCP
+
+O módulo `gcp` fornece uma interface simples para executar comandos da CLI do Google Cloud (`gcloud`) de dentro de uma tarefa do `sloth-runner`.
+
+## `gcp.exec(args)`
+
+Executa um comando `gcloud` com os argumentos especificados.
+
+### Parâmetros
+
+*   `args` (tabela): Uma tabela Lua (array) de strings representando os argumentos a serem passados para o comando `gcloud`. Por exemplo, `{"compute", "instances", "list"}`.
+
+### Retorna
+
+Uma tabela contendo o resultado da execução do comando com as seguintes chaves:
+
+*   `stdout` (string): A saída padrão do comando.
+*   `stderr` (string): A saída de erro padrão do comando.
+*   `exit_code` (número): O código de saída do comando. Um código de saída `0` geralmente indica sucesso.
+
+### Exemplo
+
+Este exemplo define uma tarefa que lista todas as instâncias do Compute Engine na região `us-central1` para um projeto específico.
+
+```lua
+-- examples/gcp_cli_example.lua
+
+TaskDefinitions = {
+  main = {
+    description = "Uma tarefa para listar instâncias de computação do GCP.",
+    tasks = {
+      {
+        name = "list-instances",
+        description = "Lista instâncias do GCE em us-central1.",
+        command = function()
+          log.info("Listando instâncias do GCP...")
+          
+          -- Requer o módulo gcp para torná-lo disponível
+          local gcp = require("gcp")
+
+          -- Executa o comando gcloud
+          local result = gcp.exec({
+            "compute", 
+            "instances", 
+            "list", 
+            "--project", "meu-projeto-gcp-id",
+            "--zones", "us-central1-a,us-central1-b"
+          })
+
+          -- Verifica o resultado
+          if result and result.exit_code == 0 then
+            log.info("Instâncias listadas com sucesso.")
+            print("--- LISTA DE INSTÂNCIAS ---")
+            print(result.stdout)
+            print("-------------------------")
+            return true, "Comando GCP bem-sucedido."
+          else
+            log.error("Falha ao listar instâncias do GCP.")
+            if result then
+              log.error("Stderr: " .. result.stderr)
+            end
+            return false, "Comando GCP falhou."
+          end
+        end
+      }
+    }
+  }
+}
+```

--- a/docs/zh/core-concepts.md
+++ b/docs/zh/core-concepts.md
@@ -64,6 +64,45 @@ TaskDefinitions = {
 *   **参数 (`params`)：** 可以通过命令行传递给任务，或在任务本身中定义。`command` 函数和 `run_if`/`abort_if` 函数可以访问它们。
 *   **输出 (`deps`)：** Lua `command` 函数可以返回一个输出表。依赖于此任务的任务可以通过 `deps` 参数访问这些输出。
 
+## 将数据导出到 CLI
+
+除了任务输出，`sloth-runner` 还提供了一个全局 `export()` 函数，允许您将数据从脚本内部直接传递到命令行输出。
+
+### `export(table)`
+
+*   **`table`**: 一个 Lua 表，其键值对将被导出。
+
+当您使用 `--return` 标志运行任务时，传递给 `export()` 函数的数据将与最终任务的输出合并，并作为单个 JSON 对象打印出来。如果存在重复的键，`export()` 函数的值将优先。
+
+这对于从脚本的任何位置提取重要信息非常有用，而不仅仅是从最后一个任务的返回值中提取。
+
+**示例:**
+
+```lua
+command = function(params, deps)
+  -- 任务逻辑...
+  local some_data = {
+    info = "这是重要数据",
+    timestamp = os.time()
+  }
+  
+  -- 导出表
+  export(some_data)
+  
+  -- 任务可以继续并返回自己的输出
+  return true, "任务完成", { status = "ok" }
+end
+```
+
+使用 `--return` 运行将产生如下 JSON 输出：
+```json
+{
+  "info": "这是重要数据",
+  "timestamp": 1678886400,
+  "status": "ok"
+}
+```
+
 ## 内置模块
 
 Sloth-Runner 将各种 Go 功能公开为 Lua 模块，允许您的任务与系统和外部服务进行交互。除了基本模块（`exec`、`fs`、`net`、`data`、`log`、`import`、`parallel`）之外，Sloth-Runner 现在还包括用于 Git、Pulumi 和 Salt 的高级模块。

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -12,6 +12,7 @@
     *   [Git 模块](./modules/git.md)
     *   [Pulumi 模块](./modules/pulumi.md)
     *   [Salt 模块](./modules/salt.md)
+    *   [GCP 模块](./modules/gcp.md)
 *   [高级示例](./advanced-examples.md)
 
 ---

--- a/docs/zh/modules/gcp.md
+++ b/docs/zh/modules/gcp.md
@@ -1,0 +1,69 @@
+# GCP 模块
+
+`gcp` 模块提供了一个简单的界面，用于从 `sloth-runner` 任务内部执行谷歌云命令行界面 (`gcloud`) 命令。
+
+## `gcp.exec(args)`
+
+使用指定的参数执行 `gcloud` 命令。
+
+### 参数
+
+*   `args` (table): 一个 Lua 表（数组），包含要传递给 `gcloud` 命令的字符串参数。例如，`{"compute", "instances", "list"}`。
+
+### 返回
+
+一个包含命令执行结果的表，其中包含以下键：
+
+*   `stdout` (string): 命令的标准输出。
+*   `stderr` (string): 命令的标准错误输出。
+*   `exit_code` (number): 命令的退出代码。退出代码 `0` 通常表示成功。
+
+### 示例
+
+此示例定义了一个任务，用于列出特定项目在 `us-central1` 区域中的所有 Compute Engine 实例。
+
+```lua
+-- examples/gcp_cli_example.lua
+
+TaskDefinitions = {
+  main = {
+    description = "一个列出 GCP 计算实例的任务。",
+    tasks = {
+      {
+        name = "list-instances",
+        description = "列出 us-central1 中的 GCE 实例。",
+        command = function()
+          log.info("正在列出 GCP 实例...")
+          
+          -- 需要 gcp 模块使其可用
+          local gcp = require("gcp")
+
+          -- 执行 gcloud 命令
+          local result = gcp.exec({
+            "compute", 
+            "instances", 
+            "list", 
+            "--project", "my-gcp-project-id",
+            "--zones", "us-central1-a,us-central1-b"
+          })
+
+          -- 检查结果
+          if result and result.exit_code == 0 then
+            log.info("成功列出实例。")
+            print("--- 实例列表 ---")
+            print(result.stdout)
+            print("---------------------")
+            return true, "GCP 命令成功。"
+          else
+            log.error("未能列出 GCP 实例。")
+            if result then
+              log.error("Stderr: " .. result.stderr)
+            end
+            return false, "GCP 命令失败。"
+          end
+        end
+      }
+    }
+  }
+}
+```

--- a/examples/export_example.lua
+++ b/examples/export_example.lua
@@ -1,0 +1,32 @@
+-- examples/export_example.lua
+
+-- This example demonstrates how to use the new global 'export' function
+-- to pass data from the script to the CLI when using the --return flag.
+
+TaskDefinitions = {
+  main = {
+    description = "A task group to demonstrate the export function.",
+    tasks = {
+      {
+        name = "export-data-task",
+        description = "Exports a table and also returns a value.",
+        command = function(params, inputs)
+          log.info("Exporting some data...")
+
+          -- Use the global export function to send a table to the runner
+          export({
+            exported_value = "this came from the export function",
+            another_key = 12345,
+            is_exported = true
+          })
+
+          log.info("Export complete. The task will now finish and return its own output.")
+
+          -- The task's own return value will be merged with the exported data.
+          -- If keys conflict, the exported value will win.
+          return true, "Task finished successfully.", { task_return_value = "this came from the task's return" }
+        end
+      }
+    }
+  }
+}

--- a/examples/gcp_example.lua
+++ b/examples/gcp_example.lua
@@ -1,0 +1,36 @@
+-- examples/gcp_example.lua
+
+-- This example demonstrates how to use the new gcp module to execute gcloud commands.
+-- It defines a simple task that lists the active gcloud configuration.
+
+TaskDefinitions = {
+  main = {
+    description = "A task group to demonstrate GCP CLI integration.",
+    tasks = {
+      {
+        name = "list-gcloud-config",
+        description = "Lists the current gcloud configuration.",
+        command = function(params, inputs)
+          log.info("Attempting to list gcloud config...")
+
+          -- Execute the gcloud command using the gcp module
+          local result = gcp.exec({"config", "list"})
+
+          -- Check the result of the execution
+          if result and result.exit_code == 0 then
+            log.info("Successfully listed gcloud config:")
+            -- Print the standard output of the command
+            print(result.stdout)
+            return true, "Successfully executed gcloud config list."
+          else
+            log.error("Failed to execute gcloud config list.")
+            if result then
+              log.error("Stderr: " .. result.stderr)
+            end
+            return false, "Failed to execute gcloud config list."
+          end
+        end
+      }
+    }
+  }
+}

--- a/examples/gcp_list_instances.lua
+++ b/examples/gcp_list_instances.lua
@@ -1,0 +1,42 @@
+-- examples/gcp_list_instances.lua
+
+-- This example demonstrates how to list GCP compute instances using the gcp module.
+-- It defines a task that calls 'gcloud compute instances list' for a specific project.
+
+TaskDefinitions = {
+  main = {
+    description = "A task group to list GCP compute instances.",
+    tasks = {
+      {
+        name = "list-gcp-instances",
+        description = "Lists GCP compute instances for project 'chalkan3'.",
+        command = function(params, inputs)
+          log.info("Attempting to list GCP compute instances for project 'chalkan3'...")
+
+          local gcp = require("gcp")
+
+          -- Define the arguments for the gcloud command
+          local gcloud_args = {"compute", "instances", "list", "--project", "chalkan3"}
+
+          -- Execute the gcloud command using the gcp module
+          local result = gcp.exec(gcloud_args)
+
+          -- Check the result of the execution
+          if result and result.exit_code == 0 then
+            log.info("Successfully listed GCP compute instances:")
+            -- Print the standard output of the command, which contains the instance list
+            print(result.stdout)
+            return true, "Successfully listed GCP compute instances."
+          else
+            log.error("Failed to list GCP compute instances.")
+            if result then
+              log.error("Exit Code: " .. result.exit_code)
+              log.error("Stderr: " .. result.stderr)
+            end
+            return false, "Failed to list GCP compute instances."
+          end
+        end
+      }
+    }
+  }
+}

--- a/internal/luainterface/gcp.go
+++ b/internal/luainterface/gcp.go
@@ -1,0 +1,60 @@
+package luainterface
+
+import (
+	"bytes"
+	"os/exec"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+type gcp struct{}
+
+func OpenGCP(L *lua.LState) {
+	L.PreloadModule("gcp", func(L *lua.LState) int {
+		mod := L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+			"exec": gcpExec,
+		})
+		L.Push(mod)
+		return 1
+	})
+}
+
+// gcpExec executes a gcloud command.
+// Lua usage: gcp.exec({"arg1", "arg2", ...})
+// Example: gcp.exec({"compute", "instances", "list", "--project", "my-project"})
+func gcpExec(L *lua.LState) int {
+	argsTable := L.CheckTable(1)
+	var args []string
+	argsTable.ForEach(func(_, value lua.LValue) {
+		args = append(args, lua.LVAsString(value))
+	})
+
+	cmd := ExecCommand("gcloud", args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	exitCode := 0
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		} else {
+			// Non-exit error (e.g., command not found)
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2 // result, error
+		}
+	}
+
+	// Create a Lua table to return the results
+	resultTable := L.NewTable()
+	resultTable.RawSetString("stdout", lua.LString(stdout.String()))
+	resultTable.RawSetString("stderr", lua.LString(stderr.String()))
+	resultTable.RawSetString("exit_code", lua.LNumber(exitCode))
+
+	L.Push(resultTable)
+	return 1 // result
+}

--- a/internal/luainterface/luainterface.go
+++ b/internal/luainterface/luainterface.go
@@ -590,7 +590,7 @@ func OpenLog(L *lua.LState) {
 
 // OpenAll preloads all available sloth-runner modules into the Lua state.
 func OpenAll(L *lua.LState) {
-	RegisterSharedSessionType(L)
+	// RegisterSharedSessionType(L)
 	OpenExec(L)
 	OpenFs(L)
 	OpenNet(L)
@@ -599,6 +599,7 @@ func OpenAll(L *lua.LState) {
 	OpenSalt(L)
 	OpenPulumi(L)
 	OpenGit(L)
+	OpenGCP(L)
 	OpenPython(L)
 }
 

--- a/internal/luainterface/pulumi.go
+++ b/internal/luainterface/pulumi.go
@@ -220,7 +220,6 @@ func pulumiStackConfig(L *lua.LState) int {
 
 var pulumiMethods = map[string]lua.LGFunction{
 	"stack":          pulumiStackFn,
-	"login":          pulumiLoginFn,
 	"install_plugin": pulumiInstallPluginFn,
 }
 
@@ -228,25 +227,6 @@ func pulumiInstallPluginFn(L *lua.LState) int {
 	pluginName := L.CheckString(1)
 	fullCommand := fmt.Sprintf("pulumi plugin install language %s --reinstall", pluginName)
 	cmd := exec.Command("bash", "-c", fullCommand)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	success := err == nil
-
-	result := L.NewTable()
-	result.RawSetString("stdout", lua.LString(stdout.String()))
-	result.RawSetString("stderr", lua.LString(stderr.String()))
-	result.RawSetString("success", lua.LBool(success))
-	L.Push(result)
-	return 1
-}
-
-func pulumiLoginFn(L *lua.LState) int {
-	url := L.OptString(1, "")
-	cmd := exec.Command("pulumi", "login", url)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/taskrunner/taskrunner.go
+++ b/internal/taskrunner/taskrunner.go
@@ -53,6 +53,7 @@ type TaskRunner struct {
 	TargetTasks []string
 	Results     []types.TaskResult
 	Outputs     map[string]interface{}
+	Exports     map[string]interface{}
 	DryRun      bool
 }
 
@@ -63,7 +64,14 @@ func NewTaskRunner(L *lua.LState, groups map[string]types.TaskGroup, targetGroup
 		TargetGroup: targetGroup,
 		TargetTasks: targetTasks,
 		Outputs:     make(map[string]interface{}),
+		Exports:     make(map[string]interface{}),
 		DryRun:      dryRun,
+	}
+}
+
+func (tr *TaskRunner) Export(data map[string]interface{}) {
+	for key, value := range data {
+		tr.Exports[key] = value
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -61,6 +61,11 @@ type TaskRunner interface {
 	RunTasksParallel(tasks []*Task, input *lua.LTable) ([]TaskResult, error)
 }
 
+// Exporter defines an interface for exporting data from a Lua script.
+type Exporter interface {
+	Export(data map[string]interface{})
+}
+
 // PythonVenv represents a Python virtual environment.
 type PythonVenv struct {
 	Path string


### PR DESCRIPTION
This PR introduces two main features: a new 'gcp' module for executing gcloud commands and a global 'export()' function in Lua for returning data to the CLI via the --return flag. It also includes comprehensive documentation updates across all languages (EN, PT, ZH) and new examples.